### PR TITLE
Fix catalog link to open in same tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     <input type="file" id="fileImportarBD" style="display:none;" accept=".json" />
 </div>
 <div class="solo-caja" style="margin-top:20px;text-align:center;">
-    <a href="catalogo.html" target="_blank" class="btn">📋 Administrar catálogo</a>
+    <a href="catalogo.html" class="btn">📋 Administrar catálogo</a>
 </div>
 <!-- Modal de Login -->
 <div id="loginModal" style="position:fixed;z-index:9999;left:0;top:0;width:100vw;height:100vh;background:#fff;display:flex;align-items:center;justify-content:center;">


### PR DESCRIPTION
## Summary
- fix the catalog link so it does not open a new tab

## Testing
- `grep -n "catalogo.html" -R`


------
https://chatgpt.com/codex/tasks/task_e_6883f39fae9083209d9222dfe9b2a754