### PR TITLE
Add history and productivity pages with sidebar

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -9,10 +9,19 @@
   <link rel="stylesheet" href="styles.css?v=1.0.4">
 </head>
 <body>
+<button id="menuButton" class="menu-button">☰</button>
+<nav id="sideMenu" class="side-menu">
+  <ul>
+    <li><a href="index.html">Inicio</a></li>
+    <li><a href="catalogo.html">Catálogo</a></li>
+    <li><a href="historial.html">Historial</a></li>
+    <li><a href="productividad.html">Productividad</a></li>
+  </ul>
+</nav>
 <div class="container">
   <div class="header">
     <h1>📋 Administrar catálogo</h1>
-    <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;top:16px;left:10px;z-index:8500;" class="btn-secondary">🌙</button>
+    <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;top:16px;left:50px;z-index:8500;" class="btn-secondary">🌙</button>
     <a href="index.html" class="btn-secondary" style="position:fixed;top:16px;right:10px;z-index:8500;">Volver</a>
   </div>
   <div id="catalogAdmin" style="margin-top:30px;">
@@ -27,6 +36,7 @@
     </table>
   </div>
 </div>
+<script src="menu.js"></script>
 <script src="catalog-admin.js?v=1.0.0"></script>
 </body>
 </html>

--- a/historial.html
+++ b/historial.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Historial de pedidos</title>
+  <script src="https://unpkg.com/dexie@3.2.4/dist/dexie.min.js"></script>
+  <link rel="stylesheet" href="styles.css?v=1.0.4">
+</head>
+<body>
+<button id="menuButton" class="menu-button">☰</button>
+<nav id="sideMenu" class="side-menu">
+  <ul>
+    <li><a href="index.html">Inicio</a></li>
+    <li><a href="catalogo.html">Catálogo</a></li>
+    <li><a href="historial.html">Historial</a></li>
+    <li><a href="productividad.html">Productividad</a></li>
+  </ul>
+</nav>
+<div class="container">
+  <div class="header">
+    <h1>📜 Historial de pedidos</h1>
+    <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;left:50px;top:16px;z-index:8500;" class="btn-secondary">🌙</button>
+  </div>
+  <div style="margin-bottom:20px;display:flex;gap:10px;align-items:end;flex-wrap:wrap;">
+    <div>
+      <label for="histInicio">Inicio:</label>
+      <input type="date" id="histInicio">
+    </div>
+    <div>
+      <label for="histFin">Fin:</label>
+      <input type="date" id="histFin">
+    </div>
+    <div>
+      <label for="histEstado">Estado:</label>
+      <select id="histEstado">
+        <option value="">Todos</option>
+        <option value="ocupada">Ocupados</option>
+        <option value="parcial">Parciales</option>
+        <option value="libre">Pagados</option>
+        <option value="anulado">Anulados</option>
+      </select>
+    </div>
+    <button class="btn" id="btnHistorial">Generar</button>
+    <button class="btn-secondary" id="exportExcel">Excel</button>
+    <button class="btn-secondary" id="exportJSON">JSON</button>
+  </div>
+  <div id="historialTabla"></div>
+</div>
+<script src="menu.js"></script>
+<script src="historial.js"></script>
+</body>
+</html>

--- a/historial.js
+++ b/historial.js
@@ -1,0 +1,62 @@
+let rowsCache = [];
+const db = new Dexie('FestejosDB');
+db.version(3).stores({
+  pedidos: "++id,fecha,hora,mesa,monto,tipo_pedido,tipo_pago,pagado,estado,timestamp,nombre,abonos,creado_por"
+});
+
+function fechaHoy() {
+  return new Date().toISOString().slice(0,10);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('histInicio').value = fechaHoy();
+  document.getElementById('histFin').value = fechaHoy();
+  document.getElementById('btnHistorial').addEventListener('click', cargarHistorial);
+  document.getElementById('exportJSON').addEventListener('click', exportJSON);
+  document.getElementById('exportExcel').addEventListener('click', exportExcel);
+  const pref = localStorage.getItem('darkMode');
+  if (pref === '1') document.body.classList.add('dark-mode');
+  document.getElementById('toggleDarkMode').onclick = () => {
+    const active = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', active ? '1' : '0');
+  };
+  cargarHistorial();
+});
+
+async function cargarHistorial() {
+  const ini = document.getElementById('histInicio').value;
+  const fin = document.getElementById('histFin').value;
+  const estado = document.getElementById('histEstado').value;
+  if (!ini || !fin) return;
+  let col = db.pedidos.where('fecha').between(ini, fin, true, true);
+  if (estado) col = col.filter(p => p.estado === estado);
+  const rows = await col.toArray();
+  rowsCache = rows;
+  let html = `<table><thead><tr><th>Fecha</th><th>Mesa/Tipo</th><th>Estado</th><th>Monto</th><th>Pagado</th></tr></thead><tbody>`;
+  rows.forEach(r => {
+    const mesa = r.mesa ? 'M'+r.mesa.toString().padStart(2,'0') : (r.tipo_pedido||'-');
+    html += `<tr><td>${r.fecha} ${r.hora}</td><td>${mesa}</td><td>${r.estado||''}</td><td>S/ ${Number(r.monto).toFixed(2)}</td><td>S/ ${Number(r.pagado).toFixed(2)}</td></tr>`;
+  });
+  html += '</tbody></table>';
+  document.getElementById('historialTabla').innerHTML = html;
+}
+
+function exportJSON() {
+  if (!rowsCache.length) return;
+  const blob = new Blob([JSON.stringify(rowsCache, null, 2)], {type:'application/json'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'historial.json';
+  a.click();
+}
+
+function exportExcel() {
+  if (!rowsCache.length) return;
+  let csv = 'Fecha,Mesa/Tipo,Estado,Monto,Pagado\n';
+  csv += rowsCache.map(r => `${r.fecha} ${r.hora},${r.mesa ? 'M'+r.mesa : r.tipo_pedido||''},${r.estado||''},${r.monto},${r.pagado}`).join('\n');
+  const blob = new Blob([csv], {type:'text/csv'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'historial.csv';
+  a.click();
+}

--- a/index.html
+++ b/index.html
@@ -11,10 +11,19 @@
     <link rel="stylesheet" href="styles.css?v=1.0.4">
 </head>
 <body>
+<button id="menuButton" class="menu-button">☰</button>
+<nav id="sideMenu" class="side-menu">
+  <ul>
+    <li><a href="index.html">Inicio</a></li>
+    <li><a href="catalogo.html">Catálogo</a></li>
+    <li><a href="historial.html">Historial</a></li>
+    <li><a href="productividad.html">Productividad</a></li>
+  </ul>
+</nav>
 <div class="container">
     <div class="header">
         <h1>🍽️ Sistema de Registro Pedidos - FESTEJOS</h1>
-        <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;top:16px;left:10px;z-index:8500;" class="btn-secondary">🌙</button>
+        <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;top:16px;left:50px;z-index:8500;" class="btn-secondary">🌙</button>
         <div class="date-info">
             <span id="currentDate"></span>
         </div>
@@ -196,6 +205,7 @@ if ('serviceWorker' in navigator) {
 }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="menu.js"></script>
 <script src="app.js?v=1.0.4"></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,11 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('menuButton');
+  const menu = document.getElementById('sideMenu');
+  if (!btn || !menu) return;
+  btn.addEventListener('click', () => {
+    menu.classList.toggle('open');
+  });
+  menu.querySelectorAll('a').forEach(a => {
+    a.addEventListener('click', () => menu.classList.remove('open'));
+  });
+});

--- a/productividad.html
+++ b/productividad.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Productividad por mozo</title>
+  <script src="https://unpkg.com/dexie@3.2.4/dist/dexie.min.js"></script>
+  <link rel="stylesheet" href="styles.css?v=1.0.4">
+</head>
+<body>
+<button id="menuButton" class="menu-button">☰</button>
+<nav id="sideMenu" class="side-menu">
+  <ul>
+    <li><a href="index.html">Inicio</a></li>
+    <li><a href="catalogo.html">Catálogo</a></li>
+    <li><a href="historial.html">Historial</a></li>
+    <li><a href="productividad.html">Productividad</a></li>
+  </ul>
+</nav>
+<div class="container">
+  <div class="header">
+    <h1>📈 Productividad por mozo</h1>
+    <button id="toggleDarkMode" title="Modo oscuro" style="position:fixed;left:50px;top:16px;z-index:8500;" class="btn-secondary">🌙</button>
+  </div>
+  <div style="margin-bottom:20px;display:flex;gap:10px;align-items:end;flex-wrap:wrap;">
+    <div>
+      <label for="prodInicio">Inicio:</label>
+      <input type="date" id="prodInicio">
+    </div>
+    <div>
+      <label for="prodFin">Fin:</label>
+      <input type="date" id="prodFin">
+    </div>
+    <button class="btn" id="btnProd">Generar</button>
+  </div>
+  <div id="prodTabla"></div>
+</div>
+<script src="menu.js"></script>
+<script src="productividad.js"></script>
+</body>
+</html>

--- a/productividad.js
+++ b/productividad.js
@@ -1,0 +1,48 @@
+const db = new Dexie('FestejosDB');
+db.version(3).stores({
+  pedidos: "++id,fecha,hora,mesa,monto,tipo_pedido,tipo_pago,pagado,estado,timestamp,nombre,abonos,creado_por"
+});
+
+function hoy() { return new Date().toISOString().slice(0,10); }
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('prodInicio').value = hoy();
+  document.getElementById('prodFin').value = hoy();
+  document.getElementById('btnProd').addEventListener('click', cargar);
+  const pref = localStorage.getItem('darkMode');
+  if (pref === '1') document.body.classList.add('dark-mode');
+  document.getElementById('toggleDarkMode').onclick = () => {
+    const active = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', active ? '1' : '0');
+  };
+  cargar();
+});
+
+async function cargar() {
+  const ini = document.getElementById('prodInicio').value;
+  const fin = document.getElementById('prodFin').value;
+  if (!ini || !fin) return;
+  const rows = await db.pedidos.where('fecha').between(ini, fin, true, true)
+    .filter(p => p.creado_por && p.estado !== 'anulado')
+    .toArray();
+  const stats = {};
+  rows.forEach(r => {
+    const mozo = r.creado_por || 'Desconocido';
+    if (!stats[mozo]) stats[mozo] = { pedidos:0, monto:0, tiempos:[] };
+    stats[mozo].pedidos++;
+    stats[mozo].monto += Number(r.pagado||0);
+    let t = 0;
+    if (Array.isArray(r.abonos) && r.abonos.length) {
+      const ultima = r.abonos[r.abonos.length-1];
+      t = (new Date(ultima.fecha) - new Date(r.timestamp)) / 60000;
+    }
+    stats[mozo].tiempos.push(t);
+  });
+  let html = `<table><thead><tr><th>Mozo</th><th>Pedidos</th><th>Monto</th><th>Tiempo Promedio (min)</th></tr></thead><tbody>`;
+  Object.entries(stats).forEach(([mozo,data]) => {
+    const prom = data.tiempos.length ? data.tiempos.reduce((a,b)=>a+b,0)/data.tiempos.length : 0;
+    html += `<tr><td>${mozo}</td><td>${data.pedidos}</td><td>S/ ${data.monto.toFixed(2)}</td><td>${prom.toFixed(1)}</td></tr>`;
+  });
+  html += '</tbody></table>';
+  document.getElementById('prodTabla').innerHTML = html;
+}

--- a/styles.css
+++ b/styles.css
@@ -939,3 +939,41 @@ body.dark-mode .resumen-pagados-section,
 body.dark-mode .reports-section,
 body.dark-mode .db-actions,
 body.dark-mode #catalogAdmin { background:#333;color:#eee; }
+
+/* ----- Sidebar Menu ----- */
+.menu-button {
+    position: fixed;
+    top: 16px;
+    left: 10px;
+    z-index: 9001;
+    background: linear-gradient(135deg, #3498db, #2980b9);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 14px;
+    cursor: pointer;
+}
+.side-menu {
+    position: fixed;
+    top: 0;
+    left: -220px;
+    width: 200px;
+    height: 100%;
+    background: #f5f5f5;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.2);
+    padding-top: 60px;
+    transition: left 0.3s;
+    z-index: 9000;
+}
+.side-menu.open { left: 0; }
+.side-menu ul { list-style:none; padding:0; }
+.side-menu li a {
+    display:block;
+    padding:12px 16px;
+    color:#333;
+    text-decoration:none;
+}
+.side-menu li a:hover { background:#ddd; }
+body.dark-mode .side-menu { background:#333; color:#eee; }
+body.dark-mode .side-menu li a { color:#eee; }
+body.dark-mode .side-menu li a:hover { background:#444; }


### PR DESCRIPTION
## Summary
- track cancelled orders and update stats accordingly
- add a sidebar menu with links to catalog, history and productivity pages
- provide a history page with export to CSV or JSON
- add productivity page to list orders per waiter

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883f699cff88320821ab6f9310fdcd6