### PR TITLE
Improve color harmony for dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,15 +21,15 @@ backdrop-filter: blur(10px);
 }
 /* Header */
 .header {
-text-align: center;
-margin-bottom: 30px;
-padding: 30px;
-background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-border-radius: 20px;
-color: white;
-box-shadow: 0 15px 35px rgba(238, 90, 36, 0.3);
-position: relative;
-overflow: hidden;
+    text-align: center;
+    margin-bottom: 30px;
+    padding: 30px;
+    background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+    border-radius: 20px;
+    color: white;
+    box-shadow: 0 15px 35px rgba(37, 117, 252, 0.3);
+    position: relative;
+    overflow: hidden;
 }
 
 .header::before {
@@ -927,18 +927,18 @@ max-width: unset;
 
 /* ----- Dark mode ----- */
 body.dark-mode {
-    background: #222;
+    background: linear-gradient(135deg, #2e2b5f 0%, #1c1842 100%);
     color: #eee;
 }
-body.dark-mode .container { background: rgba(34,34,34,0.95); }
-body.dark-mode .header { background: linear-gradient(135deg,#555,#333); }
-body.dark-mode table th { background:#444; }
-body.dark-mode table td { color:#eee; }
+body.dark-mode .container { background: rgba(40, 40, 70, 0.95); }
+body.dark-mode .header { background: linear-gradient(135deg, #4e54c8, #3f3b6d); }
+body.dark-mode table th { background:#3b3375; }
+body.dark-mode table td { color:#f1f1f1; }
 body.dark-mode .form-section,
 body.dark-mode .resumen-pagados-section,
 body.dark-mode .reports-section,
 body.dark-mode .db-actions,
-body.dark-mode #catalogAdmin { background:#333;color:#eee; }
+body.dark-mode #catalogAdmin { background:#27224d;color:#eee; }
 
 /* ----- Sidebar Menu ----- */
 .menu-button {
@@ -946,7 +946,7 @@ body.dark-mode #catalogAdmin { background:#333;color:#eee; }
     top: 16px;
     left: 10px;
     z-index: 9001;
-    background: linear-gradient(135deg, #3498db, #2980b9);
+    background: linear-gradient(135deg, #6a11cb, #2575fc);
     color: #fff;
     border: none;
     border-radius: 8px;
@@ -959,7 +959,7 @@ body.dark-mode #catalogAdmin { background:#333;color:#eee; }
     left: -220px;
     width: 200px;
     height: 100%;
-    background: #f5f5f5;
+    background: #f5f5ff;
     box-shadow: 2px 0 8px rgba(0,0,0,0.2);
     padding-top: 60px;
     transition: left 0.3s;
@@ -973,7 +973,7 @@ body.dark-mode #catalogAdmin { background:#333;color:#eee; }
     color:#333;
     text-decoration:none;
 }
-.side-menu li a:hover { background:#ddd; }
-body.dark-mode .side-menu { background:#333; color:#eee; }
+.side-menu li a:hover { background:#e0e2ff; }
+body.dark-mode .side-menu { background:#27224d; color:#eee; }
 body.dark-mode .side-menu li a { color:#eee; }
-body.dark-mode .side-menu li a:hover { background:#444; }
+body.dark-mode .side-menu li a:hover { background:#3b3375; }


### PR DESCRIPTION
## Summary
- unify palette with purple-blue tones
- update dark mode background and header colors
- tweak sidebar styles to match new scheme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6883f9420d548320b59e0c56018387de