### PR TITLE
Enable table zone color customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,20 @@
                 <input type="number" id="cajaApertura" placeholder="0.00" step="0.01">
             </div>
             <button class="btn" id="btnCajaApertura">Establecer Caja de Apertura</button>
+            <h3 style="margin-top:20px;">🎨 Colores por zona</h3>
+            <div class="form-group">
+                <label for="colorTerraza">Terraza:</label>
+                <input type="color" id="colorTerraza">
+            </div>
+            <div class="form-group">
+                <label for="colorSalon">Salón:</label>
+                <input type="color" id="colorSalon">
+            </div>
+            <div class="form-group">
+                <label for="colorBarra">Barra:</label>
+                <input type="color" id="colorBarra">
+            </div>
+            <button class="btn" id="guardarColoresZona">Guardar colores</button>
         </div>
         <h2 style="margin-top:25px; text-align:center;">🪑 MESAS</h2>
         <div class="mesas-y-especiales">

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,12 @@ margin: 0;
 padding: 0;
 box-sizing: border-box;
 }
+
+:root {
+  --color-terraza: #e0ffe0;
+  --color-salon: #e0eaff;
+  --color-barra: #ffe0e0;
+}
 body {
 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -556,6 +562,15 @@ font-size: 1.2em;
 .mesa-btn:active {
 box-shadow: 0 0 0 0 transparent;
 border-width: 3.5px;
+}
+.mesa-zona-terraza {
+  box-shadow: 0 0 0 3px var(--color-terraza) inset;
+}
+.mesa-zona-salon {
+  box-shadow: 0 0 0 3px var(--color-salon) inset;
+}
+.mesa-zona-barra {
+  box-shadow: 0 0 0 3px var(--color-barra) inset;
 }
 .mesas-seccion {
 display: flex;


### PR DESCRIPTION
## Summary
- allow setting custom colors for restaurant zones
- show color inputs in configuration section
- style tables with zone colors
- remember zone colors using localStorage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_688400aa4bd88320bfa420530d350029