### PR TITLE
Configure socket connection for Render

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,7 +132,8 @@ function configurarUIporUsuario() {
 let socket = null;
 
 function conectarSocket(rol) {
-    socket = io("http://localhost:4000"); // Cambia a tu IP/LAN si es necesario
+    // Utiliza el servidor de Render en producción
+    socket = io("https://fetregapi.onrender.com");
     socket.emit("identificarse", rol);
 
     if (rol === 'caja' || rol === 'cocina') {

--- a/server.js
+++ b/server.js
@@ -34,4 +34,5 @@ io.on('connection', socket => {
   });
 });
 
-server.listen(4000, () => console.log('Socket.IO backend en puerto 4000'));
+const PORT = process.env.PORT || 4000;
+server.listen(PORT, () => console.log(`Socket.IO backend en puerto ${PORT}`));


### PR DESCRIPTION
## Summary
- point Socket.IO client to https://fetregapi.onrender.com
- listen on Render's provided port in `server.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a52925fd88320b9f177e083b69d8d