### PR TITLE
Fix Dexie kitchen query

### DIFF
--- a/app.js
+++ b/app.js
@@ -683,7 +683,10 @@ function imprimirComandaCocina(pedido) {
     w.document.close();
 }
 setInterval(async () => {
-    const pedidos = await db.pedidos.where({ enviado_cocina: false }).toArray();
+    const pedidos = await db.pedidos
+        .where('enviado_cocina')
+        .equals(false)
+        .toArray();
     const now = Date.now();
     pedidos.forEach(p => {
         let t1 = new Date(p.timestamp).getTime();


### PR DESCRIPTION
## Summary
- fix Dexie query that retrieves pending kitchen orders

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a5ceff11083209a1190a90fe6f8c6