### PR TITLE
Add Firebase initialization

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -39,6 +39,7 @@
 </div>
 <script src="menu.js"></script>
 <script src="pwa.js"></script>
+<script type="module" src="firebase-init.js"></script>
 <script src="catalog-admin.js?v=1.0.0"></script>
 </body>
 </html>

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,0 +1,17 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-analytics.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDKVsYum6zDpKny0ZE4Ci9uuxH-Woe1a8Y",
+  authDomain: "festejospedidos.firebaseapp.com",
+  projectId: "festejospedidos",
+  storageBucket: "festejospedidos.firebasestorage.app",
+  messagingSenderId: "279687657822",
+  appId: "1:279687657822:web:9b2a76aa4af6f3b70bf7cf",
+  measurementId: "G-03TT9XMWPR"
+};
+
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);
+
+export { app, analytics };

--- a/historial.html
+++ b/historial.html
@@ -52,6 +52,7 @@
 </div>
 <script src="menu.js"></script>
 <script src="pwa.js"></script>
+<script type="module" src="firebase-init.js"></script>
 <script src="historial.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="menu.js"></script>
 <script src="pwa.js"></script>
+<script type="module" src="firebase-init.js"></script>
 <script src="app.js?v=1.0.4"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "firebase": "^9.23.0"
   }
 }

--- a/productividad.html
+++ b/productividad.html
@@ -40,6 +40,7 @@
 </div>
 <script src="menu.js"></script>
 <script src="pwa.js"></script>
+<script type="module" src="firebase-init.js"></script>
 <script src="productividad.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Firebase initialization module using CDN
- reference Firebase setup in catalogo, historial, index, and productividad pages
- declare firebase dependency in package.json

## Testing
- `npm install firebase --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a6f7679e883208090221047d46dff