### PR TITLE
Fix service worker registration and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Festejregis
+
+This project uses Firebase and a service worker. Browsers will block local `file://` requests for modules and service workers, causing errors such as:
+
+```
+Access to script ... has been blocked by CORS policy
+Failed to register a ServiceWorker: The URL protocol of the current origin ('null') is not supported.
+```
+
+To run the application, use a local HTTP server instead of opening `index.html` directly. After installing dependencies with `npm install`, you can start the included Express server:
+
+```bash
+npm start
+```
+
+Then visit `http://localhost:4000/` in your browser.
+

--- a/pwa.js
+++ b/pwa.js
@@ -1,5 +1,5 @@
 // pwa.js - registro de service worker e instalación
-if ('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator && ['http:', 'https:'].includes(window.location.protocol)) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('./sw.js').catch(err => console.error('SW error', err));
   });

--- a/server.js
+++ b/server.js
@@ -3,6 +3,11 @@ const http = require('http');
 const cors = require('cors');
 const app = express();
 app.use(cors());
+app.use(express.static(__dirname));
+
+app.get('/', (req, res) => {
+  res.sendFile(__dirname + '/index.html');
+});
 const server = http.createServer(app);
 const io = require('socket.io')(server, { cors: { origin: "*" } });
 


### PR DESCRIPTION
## Summary
- document how to run the server so that firebase and the service worker work
- avoid registering the service worker when opened via the `file:` scheme
- serve static files through Express

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a710ea0d48320852771feba9d262b